### PR TITLE
Add training pipeline with TensorBoard logging

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,37 @@
+import glob
+import os
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class GomokuDataset(Dataset):
+    """Dataset reading self-play data stored in .npz files.
+
+    Each .npz file should contain arrays 'boards' [N,4,H,W],
+    'policies' [N,H*W] and 'values' [N]. All files in the directory
+    are concatenated together.
+    """
+
+    def __init__(self, data_dir: str):
+        self.files = sorted(glob.glob(os.path.join(data_dir, '*.npz')))
+        if not self.files:
+            raise RuntimeError(f'No npz files found in {data_dir}')
+        boards, policies, values = [], [], []
+        for f in self.files:
+            data = np.load(f)
+            boards.append(data['boards'])
+            policies.append(data['policies'])
+            values.append(data['values'])
+        self.boards = np.concatenate(boards, axis=0)
+        self.policies = np.concatenate(policies, axis=0)
+        self.values = np.concatenate(values, axis=0)
+
+    def __len__(self):
+        return self.boards.shape[0]
+
+    def __getitem__(self, idx):
+        board = torch.from_numpy(self.boards[idx]).float()
+        policy = torch.from_numpy(self.policies[idx]).float()
+        value = torch.tensor(self.values[idx], dtype=torch.float32)
+        return board, policy, value

--- a/train.py
+++ b/train.py
@@ -1,0 +1,66 @@
+import argparse
+import os
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from dataset import GomokuDataset
+from net.GomokuNet import PolicyValueNet
+
+
+def train(args):
+    device = torch.device('cuda' if torch.cuda.is_available() and not args.no_cuda else 'cpu')
+
+    dataset = GomokuDataset(args.data_dir)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    model = PolicyValueNet(board_size=args.board_size)
+    model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    writer = SummaryWriter(args.log_dir)
+    global_step = 0
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        for boards, target_pi, target_v in loader:
+            boards = boards.to(device)
+            target_pi = target_pi.to(device)
+            target_v = target_v.to(device).unsqueeze(-1)
+
+            pred_pi, pred_v = model(boards)
+            policy_loss = -(target_pi * torch.log(pred_pi + 1e-8)).sum(dim=1).mean()
+            value_loss = F.mse_loss(pred_v, target_v)
+            loss = policy_loss + value_loss
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            writer.add_scalar('loss/policy', policy_loss.item(), global_step)
+            writer.add_scalar('loss/value', value_loss.item(), global_step)
+            writer.add_scalar('loss/total', loss.item(), global_step)
+            global_step += 1
+
+        print(f'Epoch {epoch}/{args.epochs} - loss: {loss.item():.4f}')
+
+    os.makedirs(os.path.dirname(args.save_path) or '.', exist_ok=True)
+    torch.save(model.state_dict(), args.save_path)
+    writer.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Train Gomoku policy-value network')
+    parser.add_argument('--data-dir', type=str, required=True, help='directory containing training .npz files')
+    parser.add_argument('--save-path', type=str, default='policy_value_net.pth', help='path to save the trained model')
+    parser.add_argument('--log-dir', type=str, default='runs', help='directory for TensorBoard logs')
+    parser.add_argument('--batch-size', type=int, default=64)
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--lr', type=float, default=1e-3)
+    parser.add_argument('--board-size', type=int, default=15)
+    parser.add_argument('--no-cuda', action='store_true', help='disable CUDA')
+    args = parser.parse_args()
+
+    train(args)


### PR DESCRIPTION
## Summary
- implement `GomokuDataset` for loading npz self-play data
- add end-to-end training script with TensorBoard logging and model saving

## Testing
- `python -m py_compile dataset.py train.py`
- *(attempted to install numpy/torch/tensorboard to run training, but installation could not complete within time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68970ff5367c83218d7e6b07db8d7e8a