### PR TITLE
Add training pipeline with TensorBoard logging

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,30 @@
+import os
+import glob
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+
+
+def load_self_play_dataset(data_dir: str) -> TensorDataset:
+    """Load and concatenate all .npz self-play files from a directory.
+
+    Each .npz file is expected to contain ``boards``, ``policies`` and ``values``
+    arrays. The returned :class:`~torch.utils.data.TensorDataset` yields
+    ``(board, policy, value)`` tuples suitable for training.
+    """
+    pattern = os.path.join(data_dir, '*.npz')
+    files = sorted(glob.glob(pattern))
+    if not files:
+        raise FileNotFoundError(f'No .npz files found in {data_dir!r}')
+
+    boards, policies, values = [], [], []
+    for path in files:
+        data = np.load(path)
+        boards.append(data['boards'])
+        policies.append(data['policies'])
+        values.append(data['values'])
+
+    boards = torch.from_numpy(np.concatenate(boards)).float()
+    policies = torch.from_numpy(np.concatenate(policies)).float()
+    values = torch.from_numpy(np.concatenate(values)).float()
+    return TensorDataset(boards, policies, values)


### PR DESCRIPTION
## Summary
- implement `GomokuDataset` for loading npz self-play data
- add end-to-end training script with TensorBoard logging and model saving

## Testing
- `python -m py_compile train.py`
- `python train.py --self-play-games 1 --simulations 5 --epochs 1 --batch-size 2 --log-dir runs_test --save-path tmp.pth --no-cuda`


------
https://chatgpt.com/codex/tasks/task_e_68970ff5367c83218d7e6b07db8d7e8a