### PR TITLE
feat: add human mode with undo and win path

### DIFF
--- a/pygame_match.py
+++ b/pygame_match.py
@@ -3,6 +3,7 @@ import time
 import random
 import numpy as np
 import pygame
+from typing import Optional
 
 from core.board import GomokuBoard
 from mcts.MCTS import MCTS
@@ -36,9 +37,11 @@ class MCTSAgent(Agent):
 
 
 class PygameMatch:
-    """Display a real-time match between two agents using pygame."""
-    def __init__(self, agent_black: Agent, agent_white: Agent, board_size: int = 15,
-                 cell_size: int = 40, margin: int = 20, delay: int = 500):
+    """Display a real-time match between two agents or a human using pygame."""
+
+    def __init__(self, agent_black: Optional[Agent], agent_white: Optional[Agent],
+                 board_size: int = 15, cell_size: int = 40, margin: int = 20,
+                 delay: int = 500):
         self.board = GomokuBoard(board_size)
         self.agent_black = agent_black
         self.agent_white = agent_white
@@ -51,6 +54,50 @@ class PygameMatch:
         size = margin * 2 + cell_size * (board_size - 1)
         self.screen = pygame.display.set_mode((size, size))
         pygame.display.set_caption("Gomoku Match")
+
+    # ---- helpers ----
+    def is_human_turn(self, player: int) -> bool:
+        return (player == 1 and self.agent_black is None) or (
+            player == -1 and self.agent_white is None
+        )
+
+    def apply_undo(self) -> int:
+        steps = 2 if ((self.agent_black is None) ^ (self.agent_white is None)) else 1
+        for _ in range(min(steps, len(self.board.history))):
+            self.board.undo()
+        # 更新赢家轨迹
+        self.board.winner_from_last()
+        return 1 if self.board.move_count % 2 == 0 else -1
+
+    def get_human_move(self):
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_u:
+                    return 'undo'
+                if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                    mx, my = event.pos
+                    x = int(round((mx - self.margin) / self.cell_size))
+                    y = int(round((my - self.margin) / self.cell_size))
+                    if 0 <= x < self.board_size and 0 <= y < self.board_size:
+                        if self.board.board[y, x] == 0:
+                            return (y, x)
+            pygame.time.wait(50)
+
+    def show_winner(self, winner: int):
+        font = pygame.font.SysFont(None, 48)
+        if winner == 1:
+            text = "Black wins"
+        elif winner == -1:
+            text = "White wins"
+        else:
+            text = "Draw"
+        img = font.render(text, True, (255, 0, 0))
+        rect = img.get_rect(center=(self.screen.get_width() // 2, self.margin // 2))
+        self.screen.blit(img, rect)
+        pygame.display.flip()
 
     def draw_board(self):
         self.screen.fill((205, 170, 125))
@@ -67,28 +114,50 @@ class PygameMatch:
                     color = (0, 0, 0) if p == 1 else (255, 255, 255)
                     pos = (self.margin + x * self.cell_size, self.margin + y * self.cell_size)
                     pygame.draw.circle(self.screen, color, pos, self.cell_size // 2 - 2)
+        if self.board.win_path:
+            pts = [(
+                self.margin + x * self.cell_size,
+                self.margin + y * self.cell_size
+            ) for y, x in self.board.win_path]
+            pygame.draw.lines(self.screen, (255, 0, 0), False, pts, 3)
         pygame.display.flip()
 
     def play(self):
         current_player = 1
         while True:
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
             self.draw_board()
             if self.board.is_terminal():
-                time.sleep(2)
+                self.show_winner(self.board.winner())
+                pygame.time.wait(2000)
                 break
-            agent = self.agent_black if current_player == 1 else self.agent_white
-            move = agent.select_move(self.board.copy(), current_player)
+
+            if self.is_human_turn(current_player):
+                res = self.get_human_move()
+                if res == 'undo':
+                    current_player = self.apply_undo()
+                    continue
+                move = res
+            else:
+                undone = False
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        pygame.quit()
+                        sys.exit()
+                    if event.type == pygame.KEYDOWN and event.key == pygame.K_u:
+                        current_player = self.apply_undo()
+                        undone = True
+                        break
+                if undone:
+                    continue
+                agent = self.agent_black if current_player == 1 else self.agent_white
+                move = agent.select_move(self.board.copy(), current_player)
+                pygame.time.wait(self.delay)
+
             self.board.step(move, current_player)
             current_player = -current_player
-            self.draw_board()
-            pygame.time.wait(self.delay)
 
 
 if __name__ == "__main__":
-    # Example usage with two random agents
-    game = PygameMatch(RandomAgent(), RandomAgent())
+    # Example usage: human vs random agent
+    game = PygameMatch(None, RandomAgent())
     game.play()


### PR DESCRIPTION
## Summary
- track winning sequence on the board and reset it on undo
- add Pygame human vs AI mode with undo support and victory highlighting

## Testing
- `python -m py_compile core/board.py pygame_match.py`
- `python - <<'PY'
from core.board import GomokuBoard
b = GomokuBoard(size=5, count_win=3)
print('start win_path', b.win_path)

b.step((0,0),1)
b.step((1,0),-1)
b.step((0,1),1)
b.step((1,1),-1)
b.step((0,2),1)
print('winner', b.winner())
print('win_path', b.win_path)

b.undo()
b.undo()
print('after undo win_path', b.win_path)
print('move_count', b.move_count)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68972c8447a48321a51b5ae2a5237496